### PR TITLE
Attempt ESPReSso v4.2.1 installation with the same easyconfig

### DIFF
--- a/easystacks/espresso-eb-4.9.4-dev.yml
+++ b/easystacks/espresso-eb-4.9.4-dev.yml
@@ -1,4 +1,4 @@
 easyconfigs:
   - ESPResSo-4.2.2-foss-2023a-software-commit.eb:
       options:
-        software-commit: df11a0e583ff6450f3544fc5d0dc535c921bd272 # Dec 17
+        software-commit: 9bb2daf1c83f5932b145a6135f3a48f969639ef3 # 4.2.1

--- a/easystacks/espresso-eb-4.9.4-dev.yml
+++ b/easystacks/espresso-eb-4.9.4-dev.yml
@@ -1,4 +1,4 @@
 easyconfigs:
   - ESPResSo-4.2.2-foss-2023a-software-commit.eb:
       options:
-        software-commit: 2ba17de6096933275abec0550981d9122e4e5f28 # release 4.2.2
+        software-commit: df11a0e583ff6450f3544fc5d0dc535c921bd272 # Dec 17


### PR DESCRIPTION
In order to test recent changes to the workflow, this PR attempts to v4.2.1 with the same easyconfig file