### PR TITLE
Add git-2.43.5-GCCcore-13.2.0-software-commit.eb

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,37 @@ This is an example repository for the setup of the build and ingestion process f
 ## Installation instructions for new project repositories
 
 This section details the steps needed to setup the infrastructure for a new project's repository and bot.
+
+Setting up an instance of the bot for a dev.eessi.io project mostly consists of following the instructions detailed at the bot's [development repository](https://github.com/EESSI/eessi-bot-software-layer). There are however a few details and differences:
+
+### app.cfg
+The bot's `app.cfg` file needs to be adjusted to the cluster it is running on. Besides the obvious (app ID that points to the correct GitHub App, private key specific to this bot, etc,), these are:
+``` ini
+[buildenv]
+build_job_script = bot/bot-build-dev.eessi.io.slurm@git@github.com:EESSI/dev.eessi.io-scripts.git
+```
+(This also requires an additional key pair, see details later!)
+
+``` ini
+[deploycfg]
+...
+bucket_name = { "dev.eessi.io": "dev.eessi.io-2024.09" }
+```
+
+For the currently available architectures in the dev.eessi.io cluster:
+``` ini
+[repo_targets]
+# defines for which repository a arch_target should be build for
+repo_target_map = {
+    "linux/x86_64/amd/zen2" : ["dev.eessi.io"],
+    "linux/x86_64/amd/zen4" : ["dev.eessi.io"],
+    "linux/aarch64/neoverse_n1" : ["dev.eessi.io"] }
+```
+
+### repos.cfg
+The `repos.cfg` file needs to be configured for `dev.eessi.io`. All that needs to be changed is a section named `[dev.eessi.io]` with `repo_name=dev.eessi.io`. All other settings can remain the same as the production bot.
+
+### Build script key pair
+The `dev.eessi.io` bot uses a different script to start build jobs. This script is at https://github.com/EESSI/dev.eessi.io-scripts and is obtained through git from that repository (the repository and the script can be changed via the `[buildenv]` section in `app.cfg`). To do so, a key pair with at least read access is required in the GitHub account that owns the bot instance (most likely this will be https://github.com/EESSIbot). If setting up a new instance, a new pubkey should be [given to that GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) (currently can be done by @boegel and @bedroge), while the corresponding private key should be in `$HOME/.ssh` of the `bot` account in the build cluster.
+
+### S3 bucket

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
-# dev.eessi.io
-Inputs for builds for dev.eessi.io repository 
+# `dev.eessi.io` Example Project
+
+This is an example repository for the setup of the build and ingestion process for EESSI's `dev.eessi.io` CernVM-FS repository. It is primarily intended for the [MultiXscale CoE](https://multixscale.eu) partners working on the development of the project's core applications.
+
+`dev.eessi.io` project repositories are hosted on GitHub and follow the naming convention: `dev.eessi.io-projectname`. Once built and ingested, installations for each project will be available in systems that have EESSI available under `/cvmfs/dev.eessi.io/2023.06/projectname/`, where `2023.06` corresponds to the matching version of EESSI's `software.eessi.io` repository and [compatibility layer](https://github.com/EESSI/filesystem-layer).
+
+## Installation instructions for new project repositories
+
+This section details the steps needed to setup the infrastructure for a new project's repository and bot.

--- a/README.md
+++ b/README.md
@@ -39,5 +39,3 @@ The `repos.cfg` file needs to be configured for `dev.eessi.io`. All that needs t
 
 ### Build script key pair
 The `dev.eessi.io` bot uses a different script to start build jobs. This script is at https://github.com/EESSI/dev.eessi.io-scripts and is obtained through git from that repository (the repository and the script can be changed via the `[buildenv]` section in `app.cfg`). To do so, a key pair with at least read access is required in the GitHub account that owns the bot instance (most likely this will be https://github.com/EESSIbot). If setting up a new instance, a new pubkey should be [given to that GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) (currently can be done by @boegel and @bedroge), while the corresponding private key should be in `$HOME/.ssh` of the `bot` account in the build cluster.
-
-### S3 bucket

--- a/easyconfigs/git-2.43.5-GCCcore-13.2.0-software-commit.eb
+++ b/easyconfigs/git-2.43.5-GCCcore-13.2.0-software-commit.eb
@@ -1,0 +1,44 @@
+easyblock = 'ConfigureMake'
+
+name = 'git'
+version = '2.43.5'
+versionsuffix = '-%(software_commit)s'
+
+homepage = 'https://git-scm.com'
+description = """Git is a free and open source distributed version control system designed
+to handle everything from small to very large projects with speed and efficiency."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+
+github_account = 'git'
+source_urls = ['https://github.com/%(github_account)s/%(name)s/archive/']
+
+sources = ['%(software_commit)s.tar.gz']
+
+builddependencies = [
+    ('binutils', '2.40'),
+    ('Autotools', '20220317'),
+]
+
+dependencies = [
+    ('cURL', '8.3.0'),
+    ('expat', '2.5.0'),
+    ('gettext', '0.22'),
+    ('Perl', '5.38.0'),
+    ('OpenSSL', '1.1', '', SYSTEM),
+]
+
+preconfigopts = 'make configure && '
+
+# Work around git build system bug.  If LIBS contains -lpthread, then configure
+# will not append -lpthread to LDFLAGS, but Makefile ignores LIBS.
+configopts = "--with-perl=${EBROOTPERL}/bin/perl --enable-pthreads='-lpthread'"
+
+postinstallcmds = ['cd contrib/subtree; make install']
+
+sanity_check_paths = {
+    'files': ['bin/git'],
+    'dirs': ['libexec/git-core', 'share'],
+}
+
+moduleclass = 'tools'

--- a/easystacks/git-eb-4.9.4-dev.yml
+++ b/easystacks/git-eb-4.9.4-dev.yml
@@ -1,0 +1,4 @@
+easyconfigs:
+  - git-2.43.5-GCCcore-13.2.0-software-commit.eb:
+      options:
+        software-commit: 337b4d400023d22207bcc3c29e9ebab31bf96fc2 # release 2.45.3


### PR DESCRIPTION
This PR is meant to test the last changes to the dev.eessi.io worflow. I chose `git` (in this case a stable release installed via `software-commit`) simply because it is quick to install and there are many releases to choose from. This makes it a nice candidate to test.

If the ingestion works correctly, then the changes to EESSI/software-layer can be merged. These should be merged from https://github.com/Neves-P/software-layer/tree/feature/dev.eessi.io-merge (note the branch is `dev.eessi.io-merge` and not `dev.eess.io`)