### PR TITLE
Add git-eb-4.9.4-dev

### DIFF
--- a/easyconfigs/git-2.43.5-GCCcore-13.2.0-software-commit.eb
+++ b/easyconfigs/git-2.43.5-GCCcore-13.2.0-software-commit.eb
@@ -1,0 +1,44 @@
+easyblock = 'ConfigureMake'
+
+name = 'git'
+version = '2.43.5'
+versionsuffix = '-%(software_commit)s'
+
+homepage = 'https://git-scm.com'
+description = """Git is a free and open source distributed version control system designed
+to handle everything from small to very large projects with speed and efficiency."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+
+github_account = 'git'
+source_urls = ['https://github.com/%(github_account)s/%(name)s/archive/']
+
+sources = ['%(software_commit)s.tar.gz']
+
+builddependencies = [
+    ('binutils', '2.40'),
+    ('Autotools', '20220317'),
+]
+
+dependencies = [
+    ('cURL', '8.3.0'),
+    ('expat', '2.5.0'),
+    ('gettext', '0.22'),
+    ('Perl', '5.38.0'),
+    ('OpenSSL', '1.1', '', SYSTEM),
+]
+
+preconfigopts = 'make configure && '
+
+# Work around git build system bug.  If LIBS contains -lpthread, then configure
+# will not append -lpthread to LDFLAGS, but Makefile ignores LIBS.
+configopts = "--with-perl=${EBROOTPERL}/bin/perl --enable-pthreads='-lpthread'"
+
+postinstallcmds = ['cd contrib/subtree; make install']
+
+sanity_check_paths = {
+    'files': ['bin/git'],
+    'dirs': ['libexec/git-core', 'share'],
+}
+
+moduleclass = 'tools'

--- a/easystacks/git-eb-4.9.4-dev.yml
+++ b/easystacks/git-eb-4.9.4-dev.yml
@@ -1,0 +1,4 @@
+easyconfigs:
+  - git-2.43.5-GCCcore-13.2.0-software-commit.eb:
+      options:
+        software-commit: 337b4d400023d22207bcc3c29e9ebab31bf96fc2 # release 2.45.3


### PR DESCRIPTION
This PR is meant to test the last changes to the dev.eessi.io worflow. I chose `git` (in this case a stable release installed via `software-commit`) simply because it is quick to install and there are many releases to choose from. This makes it a nice candidate to test.
 
If the ingestion works correctly, then the changes to EESSI/software-layer can be merged. These should be merged from https://github.com/Neves-P/software-layer/tree/feature/dev.eessi.io-merge (note the branch is `dev.eessi.io-merge` and not `dev.eess.io`)

(Follows up #13, which was closed as it contained unrelated changes)