### PR TITLE
Add SAMtools-1.21-GCC-13.2.0-software-commit

### DIFF
--- a/easyconfigs/SAMtools-1.21-GCC-13.2.0-software-commit.eb
+++ b/easyconfigs/SAMtools-1.21-GCC-13.2.0-software-commit.eb
@@ -1,0 +1,38 @@
+# #
+# This is a contribution from DeepThought HPC Service, Flinders University, Adelaide, Australia
+# Homepage:     https://staff.flinders.edu.au/research/deep-thought
+#
+# Authors::     Robert Qiao <rob.qiao@flinders.edu.au>
+# License::     MIT
+#
+# Notes::
+#
+# Updated to 1.14 and gcc-11.2.0
+# J. Sassmannshausen / GSTT
+
+name = 'SAMtools'
+version = '1.21'
+versionsuffix = '-%(software_commit)s'
+
+homepage = 'https://www.htslib.org/'
+description = """SAM Tools provide various utilities for manipulating alignments in the SAM format, 
+ including sorting, merging, indexing and generating alignments in a per-position format."""
+
+toolchain = {'name': 'GCC', 'version': '13.2.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/%(namelower)s/%(namelower)s/archive/']
+sources = [SOURCELOWER_TAR_BZ2]
+
+# The htslib component of SAMtools >= 1.4 uses zlib, bzip2 and lzma compression.
+# The latter is currently provided by XZ.
+dependencies = [
+    ('ncurses', '6.4'),
+    ('zlib', '1.2.13'),
+    ('bzip2', '1.0.8'),
+    ('XZ', '5.4.4'),
+    ('cURL', '8.3.0'),
+]
+
+
+moduleclass = 'bio'

--- a/easyconfigs/SAMtools-1.21-GCC-13.2.0-software-commit.eb
+++ b/easyconfigs/SAMtools-1.21-GCC-13.2.0-software-commit.eb
@@ -22,7 +22,7 @@ toolchain = {'name': 'GCC', 'version': '13.2.0'}
 toolchainopts = {'pic': True}
 
 source_urls = ['https://github.com/%(namelower)s/%(namelower)s/archive/']
-sources = [SOURCELOWER_TAR_BZ2]
+sources = ['%(software_commit)s.tar.gz']
 
 # The htslib component of SAMtools >= 1.4 uses zlib, bzip2 and lzma compression.
 # The latter is currently provided by XZ.

--- a/easystacks/SAMtools-eb-4.9.4-dev.yml
+++ b/easystacks/SAMtools-eb-4.9.4-dev.yml
@@ -1,0 +1,4 @@
+easyconfigs:
+  - SAMtools-1.21-GCC-13.2.0-software-commit.eb:
+      options:
+        software-commit: ec8bf989bd852cf46901b3e1a7d06d6fa10a79ff # different commit but same as release 1.21


### PR DESCRIPTION
This PR is another test of https://github.com/EESSI/software-layer/pull/885

The result should be that all builds for the target architecture land in:

`/cvmfs/dev.eessi.io/example/versions/2023.06/`

This workflow uses `EESSI-extend` with some additional changes to the overlay subdirectories in the containers.


Note: the version of SAMtools that this PR installs is 1.21. The commit hash is different (on purpose, to not overlap) from the tagged version, but the only changes are some metadata updating version numbers, CI workflow files, Makefile updates, etc.